### PR TITLE
Allow multiple stat sockets

### DIFF
--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -30,8 +30,10 @@ global
 {% endif -%}
 {% if haproxy_global.stats is defined %}
 {% if haproxy_global.stats.socket is defined %}
-    stats socket {{ haproxy_global.stats.socket }}
-{% endif -%}
+{% for socket in haproxy_global.stats.socket %}
+    stats socket {{ socket.path }}{% if socket.params is defined %} {{ socket.params }}{% endif %}
+{% endfor %}
+{% endif %}
 {% if haproxy_global.stats.timeout is defined %}
     stats timeout {{ haproxy_global.stats.timeout }}
 {% endif -%}


### PR DESCRIPTION
This patch allows multiple stat sockets to be defined, such as this :

    stats:
      sockets:
        - { path: /var/lib/haproxy/stats, params: "mode 666 level admin" }
        - { path: /var/lib/haproxy/stats_ro, params: "mode 666 level user" }
      timeout: 30s