### PR TITLE
Allow insecure-passwords in userlists.

### DIFF
--- a/templates/userlist.cfg
+++ b/templates/userlist.cfg
@@ -8,7 +8,11 @@ userlist {{ item.name }}
 {% endif %}
 {% if item.users is defined %}
 {% for user in item.users %}
+    {% if user.password is defined %}
     user {{ user.name }} password {{ user.password }}{% if user.groups is defined %} groups {{ ','.join(user.groups) }}{% endif %}
-
+    {% elif user.insecure_password is defined %}
+    user {{ user.name }} insecure-password {{ user.insecure_password }}{% if user.groups is defined %} groups {{ ','.join(user.groups) }}{% endif %}
+    {% endif %}
 {% endfor %}
+
 {% endif %}


### PR DESCRIPTION
This patch allows insecure passwords to be used and thus to not depend on the local crypt(3) function to work.