### PR TITLE
Remove jessie backports

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,7 @@
 
 - name: Add haproxy apt repo (jessie)
   apt_repository:
-    repo: deb http://http.debian.net/debian {{ ansible_distribution_release }}-backports main
+    repo: deb http://http.debian.net/debian {{ ansible_distribution_release }} main
     state: present
     update_cache: yes
   when: ansible_distribution_release == 'jessie'
@@ -43,7 +43,7 @@
 - name: Install HAProxy (apt jessie)
   apt:
     name: "{{ haproxy_package_name }}"
-    default_release: "{{ansible_distribution_release}}-backports"
+    default_release: "{{ansible_distribution_release}}"
   when: ansible_distribution_release == 'jessie'
 
 - name: Install HAProxy (Ubuntu)


### PR DESCRIPTION
This branch needs “remove-wheezy” to be applied already. It removes the installation of the jessie-backports apt repository as it is deprecated since June 2018 and mirrors expired recently, breaking apt updates.