### PR TITLE
Force jinja to generate multiple lines

### DIFF
--- a/templates/global.cfg
+++ b/templates/global.cfg
@@ -32,6 +32,7 @@ global
 {% if haproxy_global.stats.socket is defined %}
 {% for socket in haproxy_global.stats.socket %}
     stats socket {{ socket.path }}{% if socket.params is defined %} {{ socket.params }}{% endif %}
+
 {% endfor %}
 {% endif %}
 {% if haproxy_global.stats.timeout is defined %}


### PR DESCRIPTION
Because of the trailing conditional a new line is not necessarily inserted. Force it in the template.

Not sure why this was not included in PR #1 as it was sitting in my private fork.