### PR TITLE
Fix #18 - Add default socket.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,10 @@ haproxy_global:
   ssl_default_bind_ciphers: '{{ _haproxy_ssl_ciphers }}'
   ssl_default_server_options: '{{ _haproxy_ssl_options }}'
   ssl_default_server_ciphers: '{{ _haproxy_ssl_ciphers }}'
+  stats:
+    socket:
+      - path: '/run/haproxy/admin.sock'
+        params: 'mode 660 level admin'
   tune:
     ssl:
       default-dh-param: 2048


### PR DESCRIPTION
First that's better to be as close as possible of the default configuration. And the default `haproxy.cfg` contains the global below:

```
stats socket /run/haproxy/admin.sock mode 660 level admin
```
And, without this default configuration, the validation fails as described in the issue #18 : 
```
Configuration file has no error but will not start (no listener) => exit(2).
```