### PR TITLE
Add the ability to change repositories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ haproxy_config_dir: "{{ _haproxy_config_dir }}"
 haproxy_config_file: "{{ _haproxy_config_dir }}/haproxy.cfg"
 haproxy_chroot_dir: "{{ _haproxy_chroot_dir }}"
 
+haproxy_debian_repo: "{{ _haproxy_debian_repo }}"
 haproxy_package_name: "{{ _haproxy_package_name }}"
 haproxy_extra_packages: "{{ _haproxy_extra_packages }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # defaults file for haproxy
-haproxy_config_dir: "{{ _haproxy_config_dir }}"
-haproxy_config_file: "{{ _haproxy_config_dir }}/haproxy.cfg"
-haproxy_chroot_dir: "{{ _haproxy_chroot_dir }}"
+haproxy_config_dir: "/etc/haproxy"
+haproxy_config_file: "{{ haproxy_config_dir }}/haproxy.cfg"
+haproxy_chroot_dir: "/var/lib/haproxy"
 
-haproxy_debian_repo: "{{ _haproxy_debian_repo }}"
+haproxy_repo: "{{ _haproxy_repo }}"
 haproxy_package_name: "{{ _haproxy_package_name }}"
 haproxy_extra_packages: "{{ _haproxy_extra_packages }}"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,6 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-    - default.yml
 
 - name: Include distribution tasks
   include_tasks: "{{ item }}"

--- a/tasks/install/CentOS.yml
+++ b/tasks/install/CentOS.yml
@@ -3,7 +3,7 @@
   yum_repository:
     name: epel
     description: EPEL YUM repo
-    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    baseurl: "{{ haproxy_repo }}/$releasever/$basearch/
 
 - name: Install HAProxy (yum)
   yum:

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Debian - Ensure haproxy apt repo is added.
   apt_repository:
-    repo: "deb http://http.debian.net/debian {{ ansible_distribution_release }} main"
+    repo: "deb {{ haproxy_debian_repo }} {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
 

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Debian - Ensure haproxy apt repo is added.
   apt_repository:
-    repo: "deb {{ haproxy_debian_repo }} {{ ansible_distribution_release }} main"
+    repo: "deb {{ haproxy_repo }} {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
 

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Add haproxy apt repo (Ubuntu)'
   apt_repository:
-    repo: "ppa:vbernat/haproxy-1.5"
+    repo: "{{ haproxy_repo }}/haproxy-1.5"
     state: present
     update_cache: yes
   when: ansible_distribution == "Ubuntu"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,0 +1,5 @@
+---
+_haproxy__repo: "https://download.fedoraproject.org/pub"
+_haproxy_package_name: haproxy
+_haproxy_extra_packages:
+  - socat

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+_haproxy_repo: "http://http.debian.net/debian"
+_haproxy_package_name: haproxy
+_haproxy_extra_packages:
+  - socat

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,6 @@
+---
+_haproxy_repo: "ppa:vbernat"
+_haproxy_package_name: haproxy
+_haproxy_extra_packages:
+  - socat
+

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -4,6 +4,7 @@ _haproxy_config_dir: "{{ _haproxy_etc_prefix }}/haproxy"
 _haproxy_config_file: "{{ _haproxy_config_dir }}/haproxy.cfg"
 _haproxy_chroot_dir: /var/lib/haproxy
 
+_haproxy_debian_repo: "http://http.debian.net/debian"
 _haproxy_package_name: haproxy
 _haproxy_extra_packages:
   - socat

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,9 +1,4 @@
 ---
-_haproxy_etc_prefix: /etc
-_haproxy_config_dir: "{{ _haproxy_etc_prefix }}/haproxy"
-_haproxy_config_file: "{{ _haproxy_config_dir }}/haproxy.cfg"
-_haproxy_chroot_dir: /var/lib/haproxy
-
 _haproxy_debian_repo: "http://http.debian.net/debian"
 _haproxy_package_name: haproxy
 _haproxy_extra_packages:

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,5 +1,0 @@
----
-_haproxy_debian_repo: "http://http.debian.net/debian"
-_haproxy_package_name: haproxy
-_haproxy_extra_packages:
-  - socat


### PR DESCRIPTION
If you are using you own repositories server like _aptly_, that can be useful to be able to set it.

This PR moves some default variables from `vars` to `default`, because they are generic. And this PR splits `vars` in order to include specific packages stuff in the same way like the `tasks`.