### PR TITLE
Error files are not system-specific anymore

### DIFF
--- a/templates/defaults.cfg
+++ b/templates/defaults.cfg
@@ -49,12 +49,10 @@ defaults
     option {{ option }}
 {% endfor -%}
 {% endif -%}
-{% if ansible_distribution != 'CentOS' and ansible_distribution != 'Alpine' %}
 {% if haproxy_defaults.errorfile is defined %}
 {% for item in haproxy_defaults.errorfile %}
     errorfile {{ item.code }} {{ item.file }}
 {% endfor %}
-{% endif -%}
 {% endif -%}
 {% if haproxy_defaults.balance is defined %}
     balance {{ haproxy_defaults.balance }}


### PR DESCRIPTION
PR #22 made it possible, so remove the conditional around the errorfile option.