### PR TITLE
Multiple x509 certificates

### DIFF
--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -5,7 +5,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {% if item.bind is defined -%}
     {%- for bind in item.bind -%}
-        bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl crt {{ item.ssl.cert }}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
+        bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl {% for cert in item.ssl.cert %}  crt {{ cert }}{% endfor %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% endif %}{% endif %}
 
     {% endfor -%}
     {% endif -%}


### PR DESCRIPTION
This patch from @laurosn devops-coop/ansible-haproxy allows for multiple x509 certificates for one bind.