### PR TITLE
Remove epel.repo

### DIFF
--- a/templates/epel.repo
+++ b/templates/epel.repo
@@ -1,5 +1,0 @@
-[epel]
-name=EPEL
-baseurl=http://dl.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
-enabled=1
-gpgcheck=0


### PR DESCRIPTION
This file is a leftover of our previous cleanups.