### PR TITLE
SSL improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ Example
              ip: '192.168.1.100'
 ```
 
+SSL variables
+-------------
+
+```yaml
+haproxy_frontends:
+  - name: ft_default
+    bind:
+      - "0.0.0.0:443"
+    ssl:
+      cert:
+        - "/etc/ssl/private/certificat.pem"
+      ca_file: "/etc/ssl/iprivate/ca-certificates.crt"
+      options: "verify required"
+```
+
 Testing
 -------
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ haproxy_frontends:
       cert:
         - "/etc/ssl/private/certificat.pem"
       ca_file: "/etc/ssl/iprivate/ca-certificates.crt"
-      options: "verify required"
+      options:
+        - "verify"
+        - "optional"
 ```
 
 Testing

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Example
              ip: '192.168.1.100'
 ```
 
-SSL variables
--------------
+TLS configuration
+-----------------
 
 ```yaml
 haproxy_frontends:
@@ -82,9 +82,9 @@ haproxy_frontends:
       cert:
         - "/etc/ssl/private/certificat.pem"
       ca_file: "/etc/ssl/iprivate/ca-certificates.crt"
+      ciphers: "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM..."
       options:
-        - "verify"
-        - "optional"
+        - "verify optionnal"
 ```
 
 Testing

--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -6,7 +6,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {% if item.bind is defined %}
     {% for bind in item.bind %}
-    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl{% for cert in item.ssl.cert %} crt {{ cert }}{% endfor %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %} {{ item.ssl.options }}{% endif %}{% endif %}{% endif %}
+    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl{% for cert in item.ssl.cert %} crt {{ cert }}{% endfor %}{% if item.ssl.ca_file is defined %} ca-file {{ item.ssl.ca_file }}{% endif %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %} {{ item.ssl.options }}{% endif %}{% endif %}{% endif %}
 
     {% endfor %}
     {% endif %}

--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -6,7 +6,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {% if item.bind is defined %}
     {% for bind in item.bind %}
-    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl{% for cert in item.ssl.cert %} crt {{ cert }}{% endfor %}{% if item.ssl.ca_file is defined %} ca-file {{ item.ssl.ca_file }}{% endif %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %} {{ item.ssl.options }}{% endif %}{% endif %}{% endif %}
+    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl{% for cert in item.ssl.cert %} crt {{ cert }}{% endfor %}{% if item.ssl.ca_file is defined %} ca-file {{ item.ssl.ca_file }}{% endif %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %}{% for option in item.ssl.options %} {{ option }}{% endfor %}{% endif %}{% endif %}{% endif %}
 
     {% endfor %}
     {% endif %}

--- a/templates/frontend.cfg
+++ b/templates/frontend.cfg
@@ -6,7 +6,7 @@ frontend {{ item.name }} {%if item.ip is defined %}{{ item.ip }}{% endif %}{%if 
 
     {% if item.bind is defined %}
     {% for bind in item.bind %}
-    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl {% for cert in item.ssl.cert %}  crt {{ cert }}{% endfor %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %} {{ item.ssl.options }}{% endif %}{% endif %}{% endif %}
+    bind {{ bind }}{% if item.ssl is defined %}{% if item.ssl.cert is defined %} ssl{% for cert in item.ssl.cert %} crt {{ cert }}{% endfor %}{% if item.ssl.ciphers is defined %} ciphers {{ item.ssl.ciphers }}{% endif %}{% if item.ssl.options is defined %} {{ item.ssl.options }}{% endif %}{% endif %}{% endif %}
 
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
I think that the frontend ssl part is not smart. So I suggest this evolution.

* Fix of the extra spaces in the generated file
* Add ca-file to avoid the tricky include in the `options`
* Transform options from a string into an array.
* Add an example in the readme