### PR TITLE
Be able to bypass repo setup

### DIFF
--- a/tasks/install/CentOS.yml
+++ b/tasks/install/CentOS.yml
@@ -4,6 +4,7 @@
     name: epel
     description: EPEL YUM repo
     baseurl: "{{ haproxy_repo }}/$releasever/$basearch/"
+  when: haproxy_repo
 
 - name: 'Install HAProxy (yum)'
   yum:

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -4,6 +4,7 @@
     repo: "deb {{ haproxy_repo }}"
     state: present
     update_cache: yes
+  when: haproxy_repo
 
 - name: Debian - Ensure HAProxy is installed.
   apt:

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -4,7 +4,9 @@
     repo: "{{ haproxy_repo }}/haproxy-1.5"
     state: present
     update_cache: yes
-  when: ansible_distribution == "Ubuntu"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - haproxy_repo
 
 - name: Install HAProxy (Ubuntu)
   package:


### PR DESCRIPTION
The goal of this PR is not setup an external haproxy repo.  
Sometimes the haproxy package available in the official distribution repos is enough.